### PR TITLE
Fix strict aliasing warnings.

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -82,14 +82,14 @@ $Header: /usr/local/cvs/repository/mars2mseed/src/mars.h,v 1.3 2006-07-27 17:28:
                             /* 3: 12 bits mantissa, 4 bits exponent, MARS-88 */
                             /* 4: 3 bits exponent/2, 13 bits mantissa, non-differential, lite */
                             /* 5: 3 bits exponent/2, 13 bits mantissa, differential, lite */
- } leFormat;
+ } __attribute__ ((packed)) leFormat;
 
  typedef struct
  {
     int    time;	    /* time/date in ctime(3C) format */
     short  delta;	    /* time lag in ms                */
     short  mode;	    /* low nibble: sync mode; hi nibble: clock state */
- } leTime;
+ } __attribute__ ((packed)) leTime;
 
  typedef struct
  { 			    /*                         length  total   */
@@ -101,7 +101,7 @@ $Header: /usr/local/cvs/repository/mars2mseed/src/mars.h,v 1.3 2006-07-27 17:28:
     short  maxamp;	    /* max.amplitude              2     20     */
     char   scale;	    /* scale (2^N uV)             1     21     */
     char   dummy[3];	    /* ... padding                3     24     */
- } m88Head;
+ } __attribute__ ((packed)) m88Head;
 
  typedef struct 
  {                          /*                          length  total   */
@@ -115,18 +115,18 @@ $Header: /usr/local/cvs/repository/mars2mseed/src/mars.h,v 1.3 2006-07-27 17:28:
   char     scale;           /* scale (2^N uV)              1     21     */
   unsigned char triggidx;   /* trigger index / 2           1     22     */
   short    dstart;          /* start value f. diff format  2     24     */
- } mlHead;
+ } __attribute__ ((packed)) mlHead;
 
  typedef struct
  {
     m88Head	head;
     short	data[marsBlockSamples];
- } m88Block;
+ } __attribute__ ((packed)) m88Block;
 
  typedef struct
  {
     mlHead	head;
     short	data[marsBlockSamples];
- } mlBlock;
+ } __attribute__ ((packed)) mlBlock;
 
 #endif

--- a/src/mars2mseed.c
+++ b/src/mars2mseed.c
@@ -235,17 +235,17 @@ mars2group (char *mfile, MSTraceGroup *mstg)
       
       if ( verbose >= 2 )
 	ms_log (1, "MB sta='%s' chan=%d samprate=%g scale=%d time=%d c2uV=%d maxamp=%d\n",
-		mbGetStationCode(hMS->block), mbGetChan(hMS->block),
-		mbGetSampRate(hMS->block), mbGetScale(hMS->block),
-		mbGetTime(hMS->block),
-		marsBlockGetScaleFactor(hMS->block), mbGetMaxamp(hMS->block));
+		mbGetStationCode(&hMS->block), mbGetChan(&hMS->block),
+		mbGetSampRate(&hMS->block), mbGetScale(&hMS->block),
+		mbGetTime(&hMS->block),
+		marsBlockGetScaleFactor(&hMS->block), mbGetMaxamp(&hMS->block));
       
-      hData = marsBlockDecodeData (hMS->block, &scale);
+      hData = marsBlockDecodeData (&hMS->block, &scale);
       
       if ( hData && ! parseonly )
 	{
 	  /* Scale data samples, some potential gain values can result in non-integer samples */
-	  gain = marsBlockGetGain(hMS->block);
+	  gain = marsBlockGetGain(&hMS->block);
 	  
 	  totalgain = gain * scaling;
 	  
@@ -275,12 +275,12 @@ mars2group (char *mfile, MSTraceGroup *mstg)
 	  msr->numsamples = marsBlockSamples;
 	  msr->samplecnt = marsBlockSamples;
 	  msr->sampletype = 'i';
-	  msr->samprate = mbGetSampRate(hMS->block);
-	  msr->starttime = MS_EPOCH2HPTIME (mbGetTime(hMS->block));
+	  msr->samprate = mbGetSampRate(&hMS->block);
+	  msr->starttime = MS_EPOCH2HPTIME (mbGetTime(&hMS->block));
 	  
           ms_strncpclean (msr->network, forcenet, 2);
 	  if ( forcesta ) ms_strncpclean (msr->station, forcesta, 5);
-	  else ms_strncpclean (msr->station, mbGetStationCode(hMS->block), 5);
+	  else ms_strncpclean (msr->station, mbGetStationCode(&hMS->block), 5);
           ms_strncpclean (msr->location, forceloc, 2);
 	  
 	  /* Transmogrify the channel numbers to channel codes first
@@ -292,7 +292,7 @@ mars2group (char *mfile, MSTraceGroup *mstg)
 	      clp = chanlist;
 	      while ( clp != 0 )
 		{
-		  if ( *(clp->key) == ('0' + (int)mbGetChan(hMS->block)) )
+		  if ( *(clp->key) == ('0' + (int)mbGetChan(&hMS->block)) )
 		    {
 		      strncpy (msr->channel, clp->data, 10);
 		      mapped = 1;
@@ -305,19 +305,19 @@ mars2group (char *mfile, MSTraceGroup *mstg)
 	  if ( ! mapped && transchan >= 0 && transchan <= 4 )
 	    {
 	      snprintf (msr->channel, 10, "%s",
-			transmatrix[transchan][(int)mbGetChan(hMS->block)]);	      
+			transmatrix[transchan][(int)mbGetChan(&hMS->block)]);
 	      mapped = 1;
 	    }
 	  if ( ! mapped )
 	    {
-	      snprintf (msr->channel, 10, "%d", mbGetChan(hMS->block));
+	      snprintf (msr->channel, 10, "%d", mbGetChan(&hMS->block));
 	    }
 	  
 	  /* If MARS88, check for a valid time lag and warn that it's not applied */
-	  if ( mbGetBlockFormat(hMS->block) == DATABLK_FORMAT )
-	    if ( ((m88Head *)(hMS->block))->time.delta != NO_WORD )
+	  if ( mbGetBlockFormat(&hMS->block) == DATABLK_FORMAT )
+	    if ( hMS->block.m88Head.time.delta != NO_WORD )
 	      ms_log (1, "Warning: Time lag of %d ms NOT applied to N: '%s', S: '%s', L: '%s', C: '%s'\n",
-		      ((m88Head *)(hMS->block))->time.delta,
+		      hMS->block.m88Head.time.delta,
 		      msr->network, msr->station,  msr->location, msr->channel);
 	  
 	  if ( verbose >= 1 )

--- a/src/marsio.h
+++ b/src/marsio.h
@@ -17,22 +17,33 @@ $Header: /usr/local/cvs/repository/mars2mseed/src/marsio.h,v 1.4 2006-07-27 17:2
  #define msCheckStatus(a,b)   ( (a)&(b) )
  
  #define mbHeaderMacros
- #define mbGetMagic(a)	      ((((m88Head *)(a))->format_id).magic)
- #define mbGetBlockFormat(a)  ((((m88Head *)(a))->format_id).block_format)
- #define mbGetDataFormat(a)   ((((m88Head *)(a))->format_id).data_format)
+ #define mbGetMagic(a)	      ((a)->m88Head.format_id.magic)
+ #define mbGetBlockFormat(a)  ((a)->m88Head.format_id.block_format)
+ #define mbGetDataFormat(a)   ((a)->m88Head.format_id.data_format)
  
- #define mbGetChan(a)	      (((m88Head *)(a))->chno)
- #define mbGetSamp(a)	      (1<<(((m88Head *)(a))->samp_rate))
+ #define mbGetChan(a)	      ((a)->m88Head.chno)
+ #define mbGetSamp(a)	      (1<<((a)->m88Head.samp_rate))
  #define mbGetSampRate(a)     (1000.0/mbGetSamp(a))
- #define mbGetMaxamp(a)	      (((m88Head *)(a))->maxamp)
- #define mbGetScale(a)	      (1<<((m88Head *)(a))->scale)
- #define mbGetTime(a)	      ( ((((m88Head *)(a))->format_id).data_format < LITE_BLOCK_FORMAT) ? (((m88Head *)(a))->time).time : ((mlHead *)(a))->time  )
+ #define mbGetMaxamp(a)	      ((a)->m88Head.maxamp)
+ #define mbGetScale(a)	      (1<<(a)->m88Head.scale)
+ #define mbGetTime(a)	      ( ((a)->m88Head.format_id.data_format < LITE_BLOCK_FORMAT) ? (a)->m88Head.time.time : (a)->mlHead.time  )
+
+ typedef union
+ {
+  char		data[marsBlockSize];
+  leFormat	leFormat;
+  leTime	leTime;
+  m88Head	m88Head;
+  mlHead	mlHead;
+  m88Block	m88Block;
+  mlBlock	mlBlock;
+ } block_t;
 
  typedef struct
  {
   FILE	*hf;
   off_t	offset;
-  char	block[marsBlockSize];
+  block_t	block;
   
   size_t  status;
   
@@ -57,13 +68,13 @@ $Header: /usr/local/cvs/repository/mars2mseed/src/marsio.h,v 1.4 2006-07-27 17:2
  void marsStreamClose(void);
  void m88SwapBlock(m88Block *blk);
  
- int *marsBlockDecodeData(char *block,int *scale);
+ int *marsBlockDecodeData(block_t *block,int *scale);
  int marsStreamDumpBlock(marsStream *hMS);
 
- double marsBlockGetGain(char *blk);
- int marsBlockGetScaleFactor(char *blk);
- char *mbGetStationCode(char *blk);
- int mbGetStationSerial(char *blk);
+ double marsBlockGetGain(block_t *blk);
+ int marsBlockGetScaleFactor(block_t *blk);
+ char *mbGetStationCode(block_t *blk);
+ int mbGetStationSerial(block_t *blk);
  
  #ifdef __cplusplus
   }


### PR DESCRIPTION
TBH, I wrote this quite a while ago when packaging this, so I don't quite remember everything. It fixes warnings like the following, though I think it might use some GCCisms:

```
mars2mseed.c: In function 'mars2group':
mars2mseed.c:238:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   mbGetStationCode(hMS->block), mbGetChan(hMS->block),
   ^~~~~~~~~~~~~~~~
mars2mseed.c:239:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   mbGetSampRate(hMS->block), mbGetScale(hMS->block),
   ^~~~~~~~~~~~~
mars2mseed.c:239:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
mars2mseed.c:240:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   mbGetTime(hMS->block),
   ^~~~~~~~~
mars2mseed.c:240:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
mars2mseed.c:240:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
mars2mseed.c:241:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   marsBlockGetScaleFactor(hMS->block), mbGetMaxamp(hMS->block));
   ^~~~~~~~~~~~~~~~~~~~~~~
mars2mseed.c:278:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    msr->samprate = mbGetSampRate(hMS->block);
    ^~~
mars2mseed.c:279:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    msr->starttime = MS_EPOCH2HPTIME (mbGetTime(hMS->block));
    ^~~
mars2mseed.c:279:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
mars2mseed.c:279:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
mars2mseed.c:295:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     if ( *(clp->key) == ('0' + (int)mbGetChan(hMS->block)) )
     ^~
mars2mseed.c:308:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    transmatrix[transchan][(int)mbGetChan(hMS->block)]);
    ^~~~~~~~~~~
mars2mseed.c:313:8: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
        snprintf (msr->channel, 10, "%d", mbGetChan(hMS->block));
        ^~~~~~~~
mars2mseed.c:317:4: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    if ( mbGetBlockFormat(hMS->block) == DATABLK_FORMAT )
    ^~
mars2mseed.c:318:6: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
      if ( ((m88Head *)(hMS->block))->time.delta != NO_WORD )
      ^~
mars2mseed.c:320:9: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
         ((m88Head *)(hMS->block))->time.delta,
         ^
marsio.c: In function 'marsStreamGetNextBlock':
marsio.c:430:7: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
       if ( mbGetMagic(MS.block) == LEMAGICbe )
       ^~
marsio.c:431:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  switch ( ((leFormat *) &(MS.block))->block_format )
  ^~~~~~
marsio.c:447:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   mbGetMagic(MS.block),mbGetBlockFormat(MS.block),mbGetDataFormat(MS.block),
   ^~~~~~~~~~
marsio.c:447:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
marsio.c:447:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
marsio.c:448:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   mbGetChan(MS.block));
   ^~~~~~~~~
marsio.c:450:7: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
       if ( isMarsDataBlock(MS.block) && mbGetChan(MS.block) < 3 )
       ^~
```